### PR TITLE
Apply relatable<Model> patch

### DIFF
--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -2,7 +2,7 @@
 
 namespace NovaAttachMany\Http\Controllers;
 
-use Laravel\Nova\Resource;
+use Illuminate\Support\Str;
 use Illuminate\Routing\Controller;
 use Laravel\Nova\Http\Requests\NovaRequest;
 

--- a/src/Http/Controllers/AttachController.php
+++ b/src/Http/Controllers/AttachController.php
@@ -47,33 +47,33 @@ class AttachController extends Controller
             })->sortBy('display')->values();
     }
     
-	/**
-	 * Get the associatable query method name.
-	 *
-	 * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
-	 * @param  \Illuminate\Database\Eloquent\Model  $model
-	 * @return array
-	 */
-	protected function associatableQueryCallable(NovaRequest $request, $model)
-	{
-		return ($method = $this->associatableQueryMethod($request, $model))
-			? [$request->resource(), $method]
-			: [$request->newResource(), 'relatableQuery'];
-	}
+    /**
+     * Get the associatable query method name.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return array
+     */
+    protected function associatableQueryCallable(NovaRequest $request, $model)
+    {
+        return ($method = $this->associatableQueryMethod($request, $model))
+            ? [$request->resource(), $method]
+            : [$request->newResource(), 'relatableQuery'];
+    }
 
-	/**
-	 * Get the associatable query method name.
-	 *
-	 * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
-	 * @param  \Illuminate\Database\Eloquent\Model  $model
-	 * @return string
-	 */
-	protected function associatableQueryMethod(NovaRequest $request, $model)
-	{
-		$method = 'relatable'.Str::plural(class_basename($model));
+    /**
+     * Get the associatable query method name.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return string
+     */
+    protected function associatableQueryMethod(NovaRequest $request, $model)
+    {
+        $method = 'relatable'.Str::plural(class_basename($model));
 
-		if (method_exists($request->resource(), $method)) {
-			return $method;
-		}
-	}
+        if (method_exists($request->resource(), $method)) {
+            return $method;
+        }
+    }
 }


### PR DESCRIPTION
This PR applies the patch from https://github.com/dillingham/nova-attach-many/pull/29, so we can use `relatableParts`